### PR TITLE
fix: resolve API route conflict for /api/inventory/low-stock endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -118,7 +118,6 @@ async def get_low_stock_items(
     """Get items with low stock."""
     return inventory_crud.get_low_stock_items(db=db, threshold=threshold)
 
-
 @app.get(
     "/api/inventory/{item_id}",
     response_model=InventoryItemResponse,

--- a/backend/main.py
+++ b/backend/main.py
@@ -105,6 +105,21 @@ async def get_inventory_items(
 
 
 @app.get(
+    "/api/inventory/low-stock",
+    response_model=List[InventoryItemResponse],
+    tags=["Inventory"],
+    summary="Get low stock items",
+    description="Get items with low stock levels"
+)
+async def get_low_stock_items(
+    threshold: int = Query(10, ge=0, description="Stock threshold"),
+    db: Session = Depends(get_db)
+):
+    """Get items with low stock."""
+    return inventory_crud.get_low_stock_items(db=db, threshold=threshold)
+
+
+@app.get(
     "/api/inventory/{item_id}",
     response_model=InventoryItemResponse,
     tags=["Inventory"],
@@ -194,21 +209,6 @@ async def delete_inventory_item(
 async def get_categories(db: Session = Depends(get_db)):
     """Get all available categories."""
     return inventory_crud.get_categories(db=db)
-
-
-@app.get(
-    "/api/inventory/low-stock",
-    response_model=List[InventoryItemResponse],
-    tags=["Inventory"],
-    summary="Get low stock items",
-    description="Get items with low stock levels"
-)
-async def get_low_stock_items(
-    threshold: int = Query(10, ge=0, description="Stock threshold"),
-    db: Session = Depends(get_db)
-):
-    """Get items with low stock."""
-    return inventory_crud.get_low_stock_items(db=db, threshold=threshold)
 
 
 # Exception handlers


### PR DESCRIPTION
- Move /api/inventory/low-stock route before /api/inventory/{item_id} route
- Fixes issue where FastAPI was matching 'low-stock' as item_id parameter
- Ensures specific routes are matched before generic parameterized routes
- Tested with various threshold values (10, 20, 50)
- All endpoints now working correctly